### PR TITLE
Add a list of members 

### DIFF
--- a/GLOBAL/index/members.tmpl
+++ b/GLOBAL/index/members.tmpl
@@ -1,0 +1,28 @@
+<$mt:include module="Variables - Local"$>
+<mt:If name='template_debug' ne='0'><!-- ######### BEGIN OUTPUT: Index Template: Main Index (BlogID=<$mt:BlogID$>) ######### --></mt:If>
+<$mt:Var name="userblog_main_index" value="1"$>
+<$mt:Include module="Header"$>
+
+                <div class="entry-listing">
+
+<ul class="member-list">
+  <mt:Authors need_association="0" need_entry="0" any_type="1">
+    <li class="member-listitem vcard<$mtIf name="__even__"$> even</mt:If>" style="clear: left;">
+      <div class="user-pic" style="height: 46px; width: 46px; float: left; margin: 0 10px 0 0; overflow: hidden; position: relative;">
+        <a rel="contact" href="/mt/mt-cp.fcgi?__mode=view&id=<$mt:AuthorID$>" class="userpic-link" title="<$mt:AuthorDisplayName escape="html"$>"><img src="<mt:If tag="AuthorUserpicURL"><$mt:AuthorUserpicURL$><mt:Else><$mt:StaticWebPath$>images/default-userpic-90.jpg</mt:If>" width="40" height="40" alt="<$mt:AuthorDisplayName escape="html"$>" class="photo" /></a>
+      </div>
+      <div class="member-info" style="margin-left: 55px; overflow: hidden;">
+        <h4 class="fn n"><a rel="contact" href="/mt/mt-cp.fcgi?__mode=view&id=<$mt:AuthorID$>" class="userpic-link" title="<$mt:AuthorDisplayName escape="html"$>"><$mt:AuthorDisplayName$></a></h4>
+        <p><a href="<$mt:AuthorURL$>" target="_blank" class="url" rel=nofollow><$mt:AuthorURL$></a></p>
+      </div>
+    </li>
+  </mt:Authors>
+</ul>
+
+                </div><!-- #entry-listing -->
+                
+<mt:ignore><$mt:Include module="Content Navigation"$></mt:ignore>
+                
+<$mt:Include module="Footer"$>
+
+<mt:If name='template_debug' ne='0'><!-- ######### END OUTPUT: Index Template: Main Index (Blog ID=<$mt:BlogID$>) ######### --></mt:If>


### PR DESCRIPTION
Hi, I created a template to display a list of members that was discussed in the following issue.

https://github.com/davorg/blogs.perl.org/issues#issue/14

I was not sure the blog structure of this site, so I just created a folder "index" under the GLOBAL directory. This template should work when it's placed as an Index template on the portal blog. Please note that this template can be heavy to publish if there are large amount of members. The template should be configured to be published via publish que, or split the mt:Authors part into a separate module then configure "Module Caching" to " Expire upon creation or modification of: User"
