### PR TITLE
aid discovery in automated popularity contests

### DIFF
--- a/templates/GLOBAL/custom/Footer.tmpl
+++ b/templates/GLOBAL/custom/Footer.tmpl
@@ -12,6 +12,9 @@
                 <li class="first"><a href="http://github.com/blogs-perl-org/blogs.perl.org/issues">Feedback welcome</a></li>
                 <li>Hosted by <a href="http://dave.org.uk">Dave Cross</a> of <a href="http://mag-sol.com/">Magnum Solutions</a> and <a href="http://aaroncrane.co.uk/">Aaron Crane</a> of <a href="http://cutbot.net/">Cutbot</a></li>
             </ul>
+            <ul id="footer-nav">
+                <li class="first">Written in the <a href="http://perl.org">Perl Programming Language</a></li>
+            </ul>
             
             <div class="powered-by"><a href="http://www.movabletype.com/" target="_blank">Powered by Movable Type</a></div>
         </div><!-- #footer-inner -->


### PR DESCRIPTION
Adding the phrase "Perl Programming Language" will help automated popularity
contests like TIOBE discover all pages of blogs.perl.org to belong to Perl.
