### PR TITLE
remove unnecessary list bullets in footer

### DIFF
--- a/templates/GLOBAL/custom/Master CSS - Main Styles.tmpl
+++ b/templates/GLOBAL/custom/Master CSS - Main Styles.tmpl
@@ -533,7 +533,7 @@ ul#tag-cloud li.rank-1 {font-size: 30px}
 /* --------- FOOTER ----------- */
 
 #footer-inner { padding: 0 53px 10px 53px; }
-#footer-nav, #footer-nav li { float: left; padding-right: 16px; font-size: 12px; line-height: 1; color: #006c98 }
+#footer-nav, #footer-nav li { float: left; padding-right: 16px; font-size: 12px; line-height: 1; color: #006c98; list-style-type: none }
 
 #footer-nav li.first:before { content: none }
 #footer-nav li:before       { content: "\2022"; padding-right: 14px }


### PR DESCRIPTION
The footer currently has the bullets from both the default list-style-type,
as well as the :before conditional. The :before conditional is meant to
generate bullets between entries, while the list-style-type generates them
before each entry. As such, i believe disabling the list-style-type will
create the desired visuals.
